### PR TITLE
Add hf-mcp-server MCP server configuration

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "hf-mcp-server": {
+      "type": "http",
+      "url": "https://huggingface.co/mcp?login"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a project-scoped `.mcp.json` registering `hf-mcp-server` as an HTTP MCP server pointing at `https://huggingface.co/mcp?login` (Hugging Face's MCP endpoint)

## Test plan
- [x] Run `claude mcp list` in this project and confirm `hf-mcp-server` appears and connects/authenticates as expected

---
_Generated by [Claude Code](https://claude.ai/code/session_01RyPLjRSvZKVDFcPBKYQmvn)_